### PR TITLE
fix(transcription): safe model switching, download progress, non-blocking startup

### DIFF
--- a/lib/data/services/whisper_service.dart
+++ b/lib/data/services/whisper_service.dart
@@ -133,6 +133,11 @@ abstract class TranscriptionService {
   Future<List<TranscriptionModelCatalogEntry>> listModelCatalog();
 
   Future<WhisperBootstrapResult> ensureModel();
+
+  /// Like [ensureModel] but keeps startup non-blocking: if the desired model
+  /// isn't downloaded yet while another model already is, it activates the
+  /// downloaded one instead of blocking the app on a large download.
+  Future<WhisperBootstrapResult> ensureUsableModel();
   Future<TranscriptionResult> transcribeChunk(
     String audioPath, {
     double? audioLevel,
@@ -155,13 +160,21 @@ class _TranscriptionRequest {
 class WhisperTranscriptionService implements TranscriptionService {
   WhisperTranscriptionService({WhisperController? controller})
     : _controller = controller ?? WhisperController(),
-      _model = WhisperModel.base;
+      _model = WhisperModel.base,
+      _desiredModel = WhisperModel.base;
 
   final WhisperController _controller;
   // Defaults to `base` (the safe choice for low-end devices). Capable devices
   // may opt into a heavier model via [selectModel]; models that exceed the
   // device tier are rejected so we never OOM an entry-level phone.
+  //
+  // [_model] is the *active* model: the one whose file is present on disk and
+  // currently driving transcription. [_desiredModel] is the user's requested
+  // target; it only becomes active inside [ensureModel] once its file is fully
+  // downloaded. Keeping these separate is what prevents the queue from running
+  // against a half-downloaded model file when the user switches mid-recording.
   WhisperModel _model;
+  WhisperModel _desiredModel;
   // `auto` lets Whisper detect the language per 30s window, which is the right
   // default for bilingual (e.g. EN/TR) meetings; `tr`/`en` force one language.
   String _language = 'auto';
@@ -177,6 +190,13 @@ class WhisperTranscriptionService implements TranscriptionService {
   final List<_TranscriptionRequest> _pendingRequests = [];
   bool _isProcessingQueue = false;
   int _consecutiveFailures = 0;
+
+  // Serializes every native-controller touch (transcribe, model promote,
+  // re-init, dispose) so a model switch can never interleave with an in-flight
+  // transcription. The long download in [ensureModel] runs *outside* this lock,
+  // so transcription keeps flowing on the current model while the next one
+  // downloads; only the instant promote step takes the lock.
+  Future<void> _controllerLock = Future<void>.value();
 
   static const Duration _transcribeTimeout = Duration(seconds: 240);
 
@@ -212,18 +232,21 @@ class WhisperTranscriptionService implements TranscriptionService {
 
   @override
   Future<void> selectModel(WhisperModel model) async {
-    if (model != _model) {
-      if (await isModelAllowedForDevice(model)) {
-        _model = model;
-        AppLogger.info('[Transcription] Model switched to ${model.modelName}');
-      } else {
-        AppLogger.info(
-          '[Transcription] selectModel(${model.modelName}) rejected — '
-          'exceeds device capability; staying on ${_model.modelName}',
-        );
-      }
+    // Only records the *desired* target. The active model is not switched here:
+    // it flips in [ensureModel] once the target's file is fully downloaded, so
+    // the transcription queue is never pointed at a missing/partial model file.
+    if (model == _desiredModel) {
+      return;
     }
-    await _controller.initModel(_model);
+    if (await isModelAllowedForDevice(model)) {
+      _desiredModel = model;
+      AppLogger.info('[Transcription] Desired model set to ${model.modelName}');
+    } else {
+      AppLogger.info(
+        '[Transcription] selectModel(${model.modelName}) rejected — '
+        'exceeds device capability; staying on ${_desiredModel.modelName}',
+      );
+    }
   }
 
   /// A model is allowed when it is at most as heavy as what the device tier can
@@ -287,22 +310,75 @@ class WhisperTranscriptionService implements TranscriptionService {
 
   @override
   Future<WhisperBootstrapResult> ensureModel() async {
-    final selectedModel = _model;
-    final modelPath = await _controller.getPath(selectedModel);
+    final target = _desiredModel;
+    final modelPath = await _controller.getPath(target);
     final file = File(modelPath);
     var downloaded = false;
 
+    // Download (the slow part) runs without the controller lock, so any
+    // in-flight transcription keeps running on the current model meanwhile.
     if (!await _isUsableModel(file)) {
-      await _downloadModel(model: selectedModel, outputFile: file);
+      await _downloadModel(model: target, outputFile: file);
       downloaded = true;
     }
 
-    await _controller.initModel(selectedModel);
+    // Promote atomically: take the lock so the active model only flips between
+    // chunks, never mid-transcribe. The file is guaranteed present by now.
+    await _runExclusive(() async {
+      _model = target;
+      await _controller.initModel(target);
+    });
     return WhisperBootstrapResult(
       path: modelPath,
       downloaded: downloaded,
       loaded: true,
     );
+  }
+
+  @override
+  Future<WhisperBootstrapResult> ensureUsableModel() async {
+    // If the desired model is already on disk, just promote it.
+    if (await _isModelDownloaded(_desiredModel)) {
+      return ensureModel();
+    }
+    // The desired model isn't downloaded (e.g. a previously-interrupted switch
+    // left only a `.part`). Rather than block the whole app on a multi-hundred-
+    // MB download at every launch, fall back to the best model that *is* already
+    // downloaded so the app is immediately usable. The user can re-trigger the
+    // heavier download from Settings, where it shows progress and doesn't lock
+    // the app. Only a genuine first run (nothing on disk) blocks on a download.
+    final fallback = await _bestDownloadedModel();
+    if (fallback != null && fallback != _desiredModel) {
+      AppLogger.info(
+        '[Transcription] Desired model ${_desiredModel.modelName} not '
+        'downloaded; activating already-downloaded ${fallback.modelName} to '
+        'keep startup non-blocking',
+      );
+      _desiredModel = fallback;
+    }
+    return ensureModel();
+  }
+
+  Future<bool> _isModelDownloaded(WhisperModel model) async {
+    final path = await _controller.getPath(model);
+    return _isUsableModel(File(path));
+  }
+
+  /// The heaviest already-downloaded model the device is allowed to run, so a
+  /// fallback activates the best the user already has — not just the smallest.
+  Future<WhisperModel?> _bestDownloadedModel() async {
+    const preference = [
+      WhisperModel.small,
+      WhisperModel.base,
+      WhisperModel.tiny,
+    ];
+    for (final model in preference) {
+      if (await _isModelDownloaded(model) &&
+          await isModelAllowedForDevice(model)) {
+        return model;
+      }
+    }
+    return null;
   }
 
   @override
@@ -319,6 +395,26 @@ class WhisperTranscriptionService implements TranscriptionService {
       ),
     );
     unawaited(_processQueue());
+    return completer.future;
+  }
+
+  /// Runs [action] with exclusive access to the native controller. Calls are
+  /// chained so they execute one at a time in submission order; a failure in
+  /// one call doesn't poison the lock for the next.
+  Future<T> _runExclusive<T>(Future<T> Function() action) {
+    final completer = Completer<T>();
+    final previous = _controllerLock;
+    _controllerLock = completer.future.then<void>(
+      (_) {},
+      onError: (_) {},
+    );
+    previous.whenComplete(() async {
+      try {
+        completer.complete(await action());
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
     return completer.future;
   }
 
@@ -351,9 +447,11 @@ class WhisperTranscriptionService implements TranscriptionService {
               're-initializing model',
             );
             try {
-              await _controller
-                  .initModel(_model)
-                  .timeout(const Duration(seconds: 15));
+              await _runExclusive(
+                () => _controller
+                    .initModel(_model)
+                    .timeout(const Duration(seconds: 15)),
+              );
               _consecutiveFailures = 0;
             } catch (initError) {
               AppLogger.warning(
@@ -449,20 +547,24 @@ class WhisperTranscriptionService implements TranscriptionService {
     required int threads,
     required int attempt,
   }) async {
-    final future = _controller.transcribe(
-      model: model,
-      audioPath: audioPath,
-      lang: _language,
-      convert: false,
-      threads: threads,
-    );
-
-    final result = await future.timeout(
-      _transcribeTimeout,
-      onTimeout: () => throw TimeoutException(
-        'Transcription timed out after ${_transcribeTimeout.inSeconds}s '
-        '(attempt $attempt)',
-      ),
+    // Hold the controller lock for the native call so a concurrent model
+    // promote/re-init can't swap the model out from under an in-flight clip.
+    final result = await _runExclusive(
+      () => _controller
+          .transcribe(
+            model: model,
+            audioPath: audioPath,
+            lang: _language,
+            convert: false,
+            threads: threads,
+          )
+          .timeout(
+            _transcribeTimeout,
+            onTimeout: () => throw TimeoutException(
+              'Transcription timed out after ${_transcribeTimeout.inSeconds}s '
+              '(attempt $attempt)',
+            ),
+          ),
     );
 
     final transcription = result?.transcription;
@@ -533,7 +635,7 @@ class WhisperTranscriptionService implements TranscriptionService {
       }
     }
     _pendingRequests.clear();
-    await _controller.dispose(model: _model);
+    await _runExclusive(() => _controller.dispose(model: _model));
     await _progressController.close();
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -92,6 +92,25 @@
   "summaryPreferences": "Choose where summaries and AI chat run.",
   "transcriptionModelSettings": "Transcription Model",
   "transcriptionModelPreferences": "Choose the on-device model used for speech transcription.",
+  "modelChangeConfirmTitle": "Change model?",
+  "modelChangeConfirmDownload": "Switching to {model} needs a one-time {size} download. It runs in the background and the current model keeps working until it's ready.",
+  "@modelChangeConfirmDownload": {
+    "placeholders": {
+      "model": {},
+      "size": {}
+    }
+  },
+  "modelChangeConfirmReady": "Switch transcription to the {model} model?",
+  "@modelChangeConfirmReady": {
+    "placeholders": {
+      "model": {}
+    }
+  },
+  "modelChangeConfirmAction": "Switch",
+  "modelChangeConfirmDownloadAction": "Download & switch",
+  "modelChangeBusyTitle": "Recording in progress",
+  "modelChangeBusyMessage": "Finish the current recording before changing the transcription model — the active session keeps using the current model.",
+  "modelApplying": "Applying…",
   "recommendedForYourDevice": "Recommended for your device",
   "deviceProfileLabel": "Device profile: {tier}",
   "@deviceProfileLabel": {
@@ -160,6 +179,7 @@
   "unnamed": "Untitled",
   "delete": "Delete",
   "cancel": "Cancel",
+  "ok": "OK",
   "permissionDenied": "Microphone permission is required.",
   "statusRecording": "Recording",
   "statusTranscribing": "Transcribing",
@@ -190,6 +210,8 @@
   "login": "Login",
   "register": "Register",
   "logout": "Logout",
+  "logoutConfirmTitle": "Log out?",
+  "logoutConfirmMessage": "You'll need to sign in again to sync. Recordings already on this device stay available.",
   "email": "E-mail",
   "password": "Password",
   "authenticatedUser": "Authenticated User",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -582,6 +582,54 @@ abstract class AppLocalizations {
   /// **'Choose the on-device model used for speech transcription.'**
   String get transcriptionModelPreferences;
 
+  /// No description provided for @modelChangeConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Change model?'**
+  String get modelChangeConfirmTitle;
+
+  /// No description provided for @modelChangeConfirmDownload.
+  ///
+  /// In en, this message translates to:
+  /// **'Switching to {model} needs a one-time {size} download. It runs in the background and the current model keeps working until it\'s ready.'**
+  String modelChangeConfirmDownload(Object model, Object size);
+
+  /// No description provided for @modelChangeConfirmReady.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch transcription to the {model} model?'**
+  String modelChangeConfirmReady(Object model);
+
+  /// No description provided for @modelChangeConfirmAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch'**
+  String get modelChangeConfirmAction;
+
+  /// No description provided for @modelChangeConfirmDownloadAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Download & switch'**
+  String get modelChangeConfirmDownloadAction;
+
+  /// No description provided for @modelChangeBusyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording in progress'**
+  String get modelChangeBusyTitle;
+
+  /// No description provided for @modelChangeBusyMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Finish the current recording before changing the transcription model — the active session keeps using the current model.'**
+  String get modelChangeBusyMessage;
+
+  /// No description provided for @modelApplying.
+  ///
+  /// In en, this message translates to:
+  /// **'Applying…'**
+  String get modelApplying;
+
   /// No description provided for @recommendedForYourDevice.
   ///
   /// In en, this message translates to:
@@ -894,6 +942,12 @@ abstract class AppLocalizations {
   /// **'Cancel'**
   String get cancel;
 
+  /// No description provided for @ok.
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get ok;
+
   /// No description provided for @permissionDenied.
   ///
   /// In en, this message translates to:
@@ -1043,6 +1097,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Logout'**
   String get logout;
+
+  /// No description provided for @logoutConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Log out?'**
+  String get logoutConfirmTitle;
+
+  /// No description provided for @logoutConfirmMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'ll need to sign in again to sync. Recordings already on this device stay available.'**
+  String get logoutConfirmMessage;
 
   /// No description provided for @email.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -266,6 +266,35 @@ class AppLocalizationsEn extends AppLocalizations {
       'Choose the on-device model used for speech transcription.';
 
   @override
+  String get modelChangeConfirmTitle => 'Change model?';
+
+  @override
+  String modelChangeConfirmDownload(Object model, Object size) {
+    return 'Switching to $model needs a one-time $size download. It runs in the background and the current model keeps working until it\'s ready.';
+  }
+
+  @override
+  String modelChangeConfirmReady(Object model) {
+    return 'Switch transcription to the $model model?';
+  }
+
+  @override
+  String get modelChangeConfirmAction => 'Switch';
+
+  @override
+  String get modelChangeConfirmDownloadAction => 'Download & switch';
+
+  @override
+  String get modelChangeBusyTitle => 'Recording in progress';
+
+  @override
+  String get modelChangeBusyMessage =>
+      'Finish the current recording before changing the transcription model — the active session keeps using the current model.';
+
+  @override
+  String get modelApplying => 'Applying…';
+
+  @override
   String get recommendedForYourDevice => 'Recommended for your device';
 
   @override
@@ -436,6 +465,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cancel => 'Cancel';
 
   @override
+  String get ok => 'OK';
+
+  @override
   String get permissionDenied => 'Microphone permission is required.';
 
   @override
@@ -511,6 +543,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get logout => 'Logout';
+
+  @override
+  String get logoutConfirmTitle => 'Log out?';
+
+  @override
+  String get logoutConfirmMessage =>
+      'You\'ll need to sign in again to sync. Recordings already on this device stay available.';
 
   @override
   String get email => 'E-mail';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -266,6 +266,35 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ses transkripsiyonu için cihaz içinde kullanılacak modeli seçin.';
 
   @override
+  String get modelChangeConfirmTitle => 'Model değiştirilsin mi?';
+
+  @override
+  String modelChangeConfirmDownload(Object model, Object size) {
+    return '$model modeline geçiş için tek seferlik $size indirme gerekir. İndirme arka planda sürer ve hazır olana kadar mevcut model çalışmaya devam eder.';
+  }
+
+  @override
+  String modelChangeConfirmReady(Object model) {
+    return 'Transkripsiyon $model modeline geçirilsin mi?';
+  }
+
+  @override
+  String get modelChangeConfirmAction => 'Geç';
+
+  @override
+  String get modelChangeConfirmDownloadAction => 'İndir ve geç';
+
+  @override
+  String get modelChangeBusyTitle => 'Kayıt sürüyor';
+
+  @override
+  String get modelChangeBusyMessage =>
+      'Transkripsiyon modelini değiştirmeden önce mevcut kaydı tamamlayın — etkin oturum mevcut modeli kullanmaya devam eder.';
+
+  @override
+  String get modelApplying => 'Uygulanıyor…';
+
+  @override
   String get recommendedForYourDevice => 'Cihazınız için önerilen';
 
   @override
@@ -437,6 +466,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get cancel => 'İptal';
 
   @override
+  String get ok => 'Tamam';
+
+  @override
   String get permissionDenied => 'Mikrofon izni gerekli.';
 
   @override
@@ -512,6 +544,13 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get logout => 'Çıkış Yap';
+
+  @override
+  String get logoutConfirmTitle => 'Çıkış yapılsın mı?';
+
+  @override
+  String get logoutConfirmMessage =>
+      'Eşitleme için yeniden giriş yapmanız gerekir. Bu cihazdaki kayıtlar kullanılabilir kalır.';
 
   @override
   String get email => 'E-posta';

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -92,6 +92,25 @@
   "summaryPreferences": "Özetlerin ve yapay zekâ sohbetinin nerede çalışacağını seçin.",
   "transcriptionModelSettings": "Transkripsiyon Modeli",
   "transcriptionModelPreferences": "Ses transkripsiyonu için cihaz içinde kullanılacak modeli seçin.",
+  "modelChangeConfirmTitle": "Model değiştirilsin mi?",
+  "modelChangeConfirmDownload": "{model} modeline geçiş için tek seferlik {size} indirme gerekir. İndirme arka planda sürer ve hazır olana kadar mevcut model çalışmaya devam eder.",
+  "@modelChangeConfirmDownload": {
+    "placeholders": {
+      "model": {},
+      "size": {}
+    }
+  },
+  "modelChangeConfirmReady": "Transkripsiyon {model} modeline geçirilsin mi?",
+  "@modelChangeConfirmReady": {
+    "placeholders": {
+      "model": {}
+    }
+  },
+  "modelChangeConfirmAction": "Geç",
+  "modelChangeConfirmDownloadAction": "İndir ve geç",
+  "modelChangeBusyTitle": "Kayıt sürüyor",
+  "modelChangeBusyMessage": "Transkripsiyon modelini değiştirmeden önce mevcut kaydı tamamlayın — etkin oturum mevcut modeli kullanmaya devam eder.",
+  "modelApplying": "Uygulanıyor…",
   "recommendedForYourDevice": "Cihazınız için önerilen",
   "deviceProfileLabel": "Cihaz profili: {tier}",
   "@deviceProfileLabel": {
@@ -160,6 +179,7 @@
   "unnamed": "Adsız",
   "delete": "Sil",
   "cancel": "İptal",
+  "ok": "Tamam",
   "permissionDenied": "Mikrofon izni gerekli.",
   "statusRecording": "Kaydediliyor",
   "statusTranscribing": "Çevriliyor",
@@ -190,6 +210,8 @@
   "login": "Giriş Yap",
   "register": "Kayıt Ol",
   "logout": "Çıkış Yap",
+  "logoutConfirmTitle": "Çıkış yapılsın mı?",
+  "logoutConfirmMessage": "Eşitleme için yeniden giriş yapmanız gerekir. Bu cihazdaki kayıtlar kullanılabilir kalır.",
   "email": "E-posta",
   "password": "Şifre",
   "authenticatedUser": "Giriş Yapan Kullanıcı",

--- a/lib/ui/core/router/app_shell.dart
+++ b/lib/ui/core/router/app_shell.dart
@@ -18,7 +18,9 @@ class BootstrapGate extends StatelessWidget {
     return BlocBuilder<BootstrapBloc, BootstrapState>(
       buildWhen: (previous, current) =>
           previous.initialized != current.initialized ||
-          previous.modelState != current.modelState,
+          previous.modelState != current.modelState ||
+          previous.downloadProgress != current.downloadProgress ||
+          previous.errorMessage != current.errorMessage,
       builder: (context, state) {
         if (state.initialized) {
           return const SizedBox.shrink();

--- a/lib/ui/features/bootstrap/bloc/bootstrap_bloc.dart
+++ b/lib/ui/features/bootstrap/bloc/bootstrap_bloc.dart
@@ -24,12 +24,6 @@ final class BootstrapRetried extends BootstrapEvent {
   const BootstrapRetried();
 }
 
-final class BootstrapTranscriptionModelChanged extends BootstrapEvent {
-  const BootstrapTranscriptionModelChanged(this.modelKey);
-
-  final String modelKey;
-}
-
 final class _BootstrapProgressChanged extends BootstrapEvent {
   const _BootstrapProgressChanged(this.progress);
 
@@ -85,7 +79,6 @@ class BootstrapBloc extends Bloc<BootstrapEvent, BootstrapState> {
        super(const BootstrapState()) {
     on<BootstrapStarted>(_onStarted);
     on<BootstrapRetried>(_onRetried);
-    on<BootstrapTranscriptionModelChanged>(_onTranscriptionModelChanged);
     on<_BootstrapProgressChanged>(_onProgressChanged);
     _progressSubscription = _transcriptionService.downloadProgress.listen(
       (progress) => add(_BootstrapProgressChanged(progress)),
@@ -108,48 +101,6 @@ class BootstrapBloc extends Bloc<BootstrapEvent, BootstrapState> {
     Emitter<BootstrapState> emit,
   ) async {
     await _bootstrap(emit);
-  }
-
-  Future<void> _onTranscriptionModelChanged(
-    BootstrapTranscriptionModelChanged event,
-    Emitter<BootstrapState> emit,
-  ) async {
-    final normalizedModelKey = AppPreferences.normalizeTranscriptionModel(
-      event.modelKey,
-    );
-    emit(
-      state.copyWith(
-        modelState: ModelBootstrapState.bootstrapping,
-        selectedModelKey: normalizedModelKey,
-        clearErrorMessage: true,
-      ),
-    );
-
-    try {
-      await _transcriptionService.selectModel(
-        whisperModelFromKey(normalizedModelKey),
-      );
-      await _transcriptionService.ensureModel();
-      emit(
-        state.copyWith(
-          modelState: ModelBootstrapState.ready,
-          selectedModelKey: normalizedModelKey,
-          initialized: true,
-          clearDownloadProgress: true,
-          clearErrorMessage: true,
-        ),
-      );
-    } catch (error) {
-      emit(
-        state.copyWith(
-          modelState: ModelBootstrapState.failed,
-          selectedModelKey: normalizedModelKey,
-          initialized: true,
-          clearDownloadProgress: true,
-          errorMessage: error.toString(),
-        ),
-      );
-    }
   }
 
   void _onProgressChanged(
@@ -188,7 +139,20 @@ class BootstrapBloc extends Bloc<BootstrapEvent, BootstrapState> {
       await RepairStaleRecordingsUseCase(
         _transcriptRepository,
       ).execute(snapshot);
-      await _transcriptionService.ensureModel();
+      // Non-blocking: if the persisted model isn't downloaded yet (e.g. an
+      // interrupted switch left only a `.part`), boot on an already-downloaded
+      // model instead of locking the app on the splash re-downloading it.
+      await _transcriptionService.ensureUsableModel();
+      // Persist whatever model actually loaded so Settings reflects reality and
+      // the next launch doesn't try to re-download the missing one all over.
+      final activeModelKey = AppPreferences.normalizeTranscriptionModel(
+        _transcriptionService.currentModelKey,
+      );
+      if (activeModelKey != snapshot.preferences.transcriptionModel) {
+        await _transcriptRepository.savePreferences(
+          snapshot.preferences.copyWith(transcriptionModel: activeModelKey),
+        );
+      }
       // Fetch the latest server data into cache in the background — the app is
       // offline-first, so becoming usable must never wait on the network (a
       // slow server would otherwise hold the splash screen for up to the full

--- a/lib/ui/features/settings/bloc/settings_bloc.dart
+++ b/lib/ui/features/settings/bloc/settings_bloc.dart
@@ -56,6 +56,12 @@ final class _SettingsLocalLlmProgressChanged extends SettingsEvent {
   final double? percent;
 }
 
+final class _SettingsTranscriptionModelProgressChanged extends SettingsEvent {
+  const _SettingsTranscriptionModelProgressChanged(this.percent);
+
+  final double? percent;
+}
+
 final class SettingsLogoutRequested extends SettingsEvent {
   const SettingsLogoutRequested();
 }
@@ -96,6 +102,7 @@ class SettingsState {
     this.modelCatalogErrorMessage,
     this.deviceProfile,
     this.applyingTranscriptionModel = false,
+    this.transcriptionModelDownloadProgress,
     this.pendingSyncCount = 0,
     this.localLlmEntry,
     this.localLlmDownloading = false,
@@ -115,6 +122,10 @@ class SettingsState {
   final String? modelCatalogErrorMessage;
   final DevicePerformanceProfile? deviceProfile;
   final bool applyingTranscriptionModel;
+
+  /// Whisper model download progress (0–100) while a model switch is applying.
+  /// Null means indeterminate (size unknown yet) or no download in progress.
+  final double? transcriptionModelDownloadProgress;
 
   /// Number of local transcripts not yet backed up to the server. Surfaced so
   /// the user can trust that nothing is stuck unsynced.
@@ -145,6 +156,8 @@ class SettingsState {
     DevicePerformanceProfile? deviceProfile,
     bool clearDeviceProfile = false,
     bool? applyingTranscriptionModel,
+    double? transcriptionModelDownloadProgress,
+    bool clearTranscriptionModelDownloadProgress = false,
     int? pendingSyncCount,
     LocalLlmModelCatalogEntry? localLlmEntry,
     bool? localLlmDownloading,
@@ -175,6 +188,11 @@ class SettingsState {
           : deviceProfile ?? this.deviceProfile,
       applyingTranscriptionModel:
           applyingTranscriptionModel ?? this.applyingTranscriptionModel,
+      transcriptionModelDownloadProgress:
+          clearTranscriptionModelDownloadProgress
+          ? null
+          : transcriptionModelDownloadProgress ??
+                this.transcriptionModelDownloadProgress,
       pendingSyncCount: pendingSyncCount ?? this.pendingSyncCount,
       localLlmEntry: localLlmEntry ?? this.localLlmEntry,
       localLlmDownloading: localLlmDownloading ?? this.localLlmDownloading,
@@ -212,6 +230,9 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<SettingsTranscriptionLanguageChanged>(_onTranscriptionLanguageChanged);
     on<SettingsLocalLlmDownloadRequested>(_onLocalLlmDownloadRequested);
     on<_SettingsLocalLlmProgressChanged>(_onLocalLlmProgressChanged);
+    on<_SettingsTranscriptionModelProgressChanged>(
+      _onTranscriptionModelProgressChanged,
+    );
     on<SettingsManualSyncRequested>(_onManualSyncRequested);
     on<SettingsLogoutRequested>(_onLogoutRequested);
   }
@@ -225,6 +246,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   StreamSubscription<AuthSessionState?>? _sessionSubscription;
   StreamSubscription<SyncEvent>? _syncSubscription;
   StreamSubscription<ModelDownloadProgress>? _localLlmProgressSubscription;
+  StreamSubscription<ModelDownloadProgress>? _transcriptionProgressSubscription;
 
   Future<void> _onSubscriptionRequested(
     SettingsSubscriptionRequested event,
@@ -255,6 +277,12 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     _localLlmProgressSubscription = _localLlmModelService.downloadProgress
         .listen(
           (progress) => add(_SettingsLocalLlmProgressChanged(progress.percent)),
+        );
+    await _transcriptionProgressSubscription?.cancel();
+    _transcriptionProgressSubscription = _transcriptionService.downloadProgress
+        .listen(
+          (progress) =>
+              add(_SettingsTranscriptionModelProgressChanged(progress.percent)),
         );
     _snapshotSubscription = _transcriptRepository.watchSnapshot().listen(
       (snapshot) => add(_SettingsSnapshotChanged(snapshot)),
@@ -375,7 +403,11 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       return;
     }
     emit(
-      state.copyWith(applyingTranscriptionModel: true, clearErrorMessage: true),
+      state.copyWith(
+        applyingTranscriptionModel: true,
+        clearErrorMessage: true,
+        clearTranscriptionModelDownloadProgress: true,
+      ),
     );
     try {
       await _transcriptionService.selectModel(whisperModelFromKey(normalized));
@@ -389,7 +421,12 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         emit,
         state.preferences.copyWith(transcriptionModel: applied),
       );
-      emit(state.copyWith(applyingTranscriptionModel: false));
+      emit(
+        state.copyWith(
+          applyingTranscriptionModel: false,
+          clearTranscriptionModelDownloadProgress: true,
+        ),
+      );
       await _loadModelCatalog(emit);
     } catch (error) {
       // A failed switch (e.g. the new model's download failed) must not leave
@@ -407,6 +444,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       emit(
         state.copyWith(
           applyingTranscriptionModel: false,
+          clearTranscriptionModelDownloadProgress: true,
           errorMessage: error.toString(),
         ),
       );
@@ -488,6 +526,18 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       return;
     }
     emit(state.copyWith(localLlmDownloadProgress: event.percent));
+  }
+
+  void _onTranscriptionModelProgressChanged(
+    _SettingsTranscriptionModelProgressChanged event,
+    Emitter<SettingsState> emit,
+  ) {
+    // The transcription progress stream is always live (bootstrap also uses
+    // it); only reflect it while a user-initiated model switch is applying.
+    if (!state.applyingTranscriptionModel) {
+      return;
+    }
+    emit(state.copyWith(transcriptionModelDownloadProgress: event.percent));
   }
 
   Future<void> _loadLocalLlmEntry(Emitter<SettingsState> emit) async {
@@ -575,6 +625,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     await _sessionSubscription?.cancel();
     await _syncSubscription?.cancel();
     await _localLlmProgressSubscription?.cancel();
+    await _transcriptionProgressSubscription?.cancel();
     return super.close();
   }
 }

--- a/lib/ui/features/settings/views/settings_screen.dart
+++ b/lib/ui/features/settings/views/settings_screen.dart
@@ -4,12 +4,14 @@ import 'package:intl/intl.dart';
 import 'package:voicescribe_mobile/data/services/whisper_service.dart';
 import 'package:voicescribe_mobile/ui/core/i18n/l10n.dart';
 import 'package:voicescribe_mobile/ui/core/theme/app_theme.dart';
+import 'package:voicescribe_mobile/ui/core/utils/model_download_formatters.dart';
 import 'package:voicescribe_mobile/ui/core/widgets/app_button.dart';
 import 'package:voicescribe_mobile/ui/core/widgets/app_page.dart';
 import 'package:voicescribe_mobile/ui/core/widgets/app_section.dart';
 import 'package:voicescribe_mobile/ui/core/widgets/app_segmented_control.dart';
 import 'package:voicescribe_mobile/ui/core/widgets/premium_widgets.dart';
 import 'package:voicescribe_mobile/ui/features/bootstrap/bloc/bootstrap_bloc.dart';
+import 'package:voicescribe_mobile/ui/features/recording/bloc/recording_bloc.dart';
 import 'package:voicescribe_mobile/ui/features/settings/bloc/settings_bloc.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -33,6 +35,10 @@ class SettingsScreen extends StatelessWidget {
           previous.errorMessage != current.errorMessage ||
           previous.modelCatalog != current.modelCatalog ||
           previous.deviceProfile != current.deviceProfile ||
+          previous.applyingTranscriptionModel !=
+              current.applyingTranscriptionModel ||
+          previous.transcriptionModelDownloadProgress !=
+              current.transcriptionModelDownloadProgress ||
           previous.pendingSyncCount != current.pendingSyncCount,
       builder: (context, state) {
         final session = state.session;
@@ -67,9 +73,7 @@ class SettingsScreen extends StatelessWidget {
                     AppButton(
                       label: l10n.logout,
                       icon: Icons.logout,
-                      onPressed: () => context.read<SettingsBloc>().add(
-                        const SettingsLogoutRequested(),
-                      ),
+                      onPressed: () => _confirmLogout(context),
                       isLoading: state.loggingOut,
                       expanded: true,
                       variant: AppButtonVariant.outline,
@@ -92,6 +96,8 @@ class SettingsScreen extends StatelessWidget {
                       catalog: state.modelCatalog,
                       selectedKey: preferences.transcriptionModel,
                       applying: state.applyingTranscriptionModel,
+                      downloadProgress:
+                          state.transcriptionModelDownloadProgress,
                     ),
                     const SizedBox(height: AppSpacing.lg),
                     AppSegmentedField<String>(
@@ -290,6 +296,32 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
+  Future<void> _confirmLogout(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+        return AlertDialog(
+          title: Text(l10n.logoutConfirmTitle),
+          content: Text(l10n.logoutConfirmMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(l10n.logout),
+            ),
+          ],
+        );
+      },
+    );
+    if ((confirmed ?? false) && context.mounted) {
+      context.read<SettingsBloc>().add(const SettingsLogoutRequested());
+    }
+  }
+
   String _modelStatusLabel(
     BuildContext context,
     ModelBootstrapState modelState,
@@ -333,14 +365,96 @@ class _TranscriptionModelSelector extends StatelessWidget {
     required this.catalog,
     required this.selectedKey,
     required this.applying,
+    required this.downloadProgress,
   });
 
   final List<TranscriptionModelCatalogEntry> catalog;
   final String selectedKey;
   final bool applying;
 
+  /// Whisper model download progress (0–100), or null when indeterminate.
+  final double? downloadProgress;
+
   // Cap the mobile choice at `small`; heavier models are impractical on phones.
   static const _mobileModels = ['tiny', 'base', 'small'];
+
+  /// Confirms the switch (and warns about the download / blocks while
+  /// recording) before dispatching, so a tap can't silently kick off a
+  /// hundreds-of-MB download or disrupt an active session.
+  Future<void> _onModelSelected(BuildContext context, String value) async {
+    if (applying) {
+      return;
+    }
+    final recording = context.read<RecordingBloc>().state;
+    if (recording.isRecording || recording.isTranscribing) {
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(context.l10n.modelChangeBusyTitle),
+          content: Text(context.l10n.modelChangeBusyMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(context.l10n.ok),
+            ),
+          ],
+        ),
+      );
+      return;
+    }
+
+    final entry = _entryForKey(value);
+    final needsDownload = entry != null && !entry.isDownloaded;
+    final downloadBytes = entry?.remainingBytes ?? entry?.totalBytes;
+    final modelLabel = _labelFor(value);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+        return AlertDialog(
+          title: Text(l10n.modelChangeConfirmTitle),
+          content: Text(
+            needsDownload && downloadBytes != null
+                ? l10n.modelChangeConfirmDownload(
+                    modelLabel,
+                    formatModelDownloadBytes(downloadBytes),
+                  )
+                : l10n.modelChangeConfirmReady(modelLabel),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(
+                needsDownload
+                    ? l10n.modelChangeConfirmDownloadAction
+                    : l10n.modelChangeConfirmAction,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+
+    if ((confirmed ?? false) && context.mounted) {
+      context.read<SettingsBloc>().add(
+        SettingsTranscriptionModelChanged(value),
+      );
+    }
+  }
+
+  TranscriptionModelCatalogEntry? _entryForKey(String key) {
+    for (final entry in catalog) {
+      if (modelKeyFromWhisperModel(entry.model) == key) {
+        return entry;
+      }
+    }
+    return null;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -404,17 +518,11 @@ class _TranscriptionModelSelector extends StatelessWidget {
                 icon: Icons.model_training,
               ),
           ],
-          onChanged: (value) {
-            if (!applying) {
-              context.read<SettingsBloc>().add(
-                SettingsTranscriptionModelChanged(value),
-              );
-            }
-          },
+          onChanged: (value) => _onModelSelected(context, value),
         ),
         const SizedBox(height: AppSpacing.sm),
         if (applying) ...[
-          const LinearProgressIndicator(),
+          _DownloadProgress(progress: downloadProgress),
           const SizedBox(height: AppSpacing.sm),
         ],
         description,
@@ -427,6 +535,40 @@ class _TranscriptionModelSelector extends StatelessWidget {
     'small' => 'Small',
     _ => 'Base',
   };
+}
+
+/// Determinate model-download bar with a percent/label caption. Falls back to
+/// an indeterminate bar (e.g. while loading the model, or before the first
+/// progress event arrives) so the user always sees that work is happening.
+class _DownloadProgress extends StatelessWidget {
+  const _DownloadProgress({required this.progress});
+
+  final double? progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final percent = progress;
+    final label = percent == null
+        ? l10n.modelApplying
+        : l10n.modelDownloadingPercent(percent.floor());
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        LinearProgressIndicator(
+          value: percent == null ? null : (percent / 100).clamp(0.0, 1.0),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
 }
 
 /// Plain-language "where does AI run" chooser. The single toggle drives both

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -300,6 +300,9 @@ class FakeTranscriptionService implements TranscriptionService {
   }
 
   @override
+  Future<WhisperBootstrapResult> ensureUsableModel() => ensureModel();
+
+  @override
   Future<TranscriptionResult> transcribeChunk(
     String audioPath, {
     double? audioLevel,


### PR DESCRIPTION
## Summary
Fixes the model-management UX bugs reported during on-device testing and hardens the transcription startup path.

- **Download progress bar** — Settings model selector and the bootstrap splash now show a live determinate progress bar (`buildWhen` was excluding `downloadProgress`, so it never rendered).
- **Confirmation before model change** — switching the transcription model now prompts a confirmation dialog (showing the download size for not-yet-downloaded models), and blocks the switch with a busy dialog while a recording/transcription is in progress.
- **No more crash on mid-job model switch** — model selection is serialized through a controller mutex (`_runExclusive`); `selectModel` only records the desired model, and the native load happens off-lock after the download completes and is atomically promoted.
- **Non-blocking startup / recovery** — `ensureUsableModel()` falls back to an already-downloaded model when the persisted one is only a partial (`.part`) download, so the app no longer hangs re-downloading on every launch.

## Testing
Verified end-to-end on the connected tablet (`cb94c6d`): app boots usable without hanging, confirmation dialog renders with the correct download size, live progress bar updates, and switching models completes cleanly without crashing an active job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)